### PR TITLE
week9_da fix: load all weights into teacher model

### DIFF
--- a/week9_da/utils.py
+++ b/week9_da/utils.py
@@ -13,14 +13,14 @@ class Model:
         self.emb_size, self.hid_size = emb_size, hid_size
 
         with tf.variable_scope(name):
-            self.emb_inp = L.Embedding(len(inp_voc), emb_size)
-            self.emb_out = L.Embedding(len(out_voc), emb_size)
+            self.emb_inp = L.Embedding(len(inp_voc), emb_size, name='embedding_1')
+            self.emb_out = L.Embedding(len(out_voc), emb_size, name='embedding_2')
             self.enc_fw = LSTMCell('enc_fw', emb_size, hid_size)
             self.enc_bw = LSTMCell('enc_bw', emb_size, hid_size)
 
             self.dec = LSTMCell('decoder', emb_size + hid_size * 2, hid_size)
             self.attn = AttentionLayer('attn', 2 * hid_size, hid_size, attn_size)
-            self.logits = L.Dense(len(out_voc))
+            self.logits = L.Dense(len(out_voc), name='dense_1')
 
             # prepare to translate_lines
             self.inp = tf.placeholder('int32', [None, None])


### PR DESCRIPTION
Line 
`utils.load(tf.trainable_variables(), 'teacher.npz')`
in **Domain adaptation with KL penalty task** from [seminar.ipynb](https://github.com/yandexdataschool/nlp_course/blob/master/week9_da/seminar.ipynb) yields warning 

> **Variables not initialized**: mod/enc_fw/i2c:0 mod/enc_fw/h2c:0 mod/enc_fw/b_c:0 mod/enc_fw/i2f:0 mod/enc_fw/h2f:0 mod/enc_fw/b_f:0 mod/enc_fw/i2i:0 mod/enc_fw/h2i:0 mod/enc_fw/b_i:0 mod/enc_fw/i2o:0 mod/enc_fw/h2o:0 mod/enc_fw/b_o:0 mod/enc_bw/i2c:0 mod/enc_bw/h2c:0 mod/enc_bw/b_c:0 mod/enc_bw/i2f:0 mod/enc_bw/h2f:0 mod/enc_bw/b_f:0 mod/enc_bw/i2i:0 mod/enc_bw/h2i:0 mod/enc_bw/b_i:0 mod/enc_bw/i2o:0 mod/enc_bw/h2o:0 mod/enc_bw/b_o:0 mod/decoder/i2c:0 mod/decoder/h2c:0 mod/decoder/b_c:0 mod/decoder/i2f:0 mod/decoder/h2f:0 mod/decoder/b_f:0 mod/decoder/i2i:0 mod/decoder/h2i:0 mod/decoder/b_i:0 mod/decoder/i2o:0 mod/decoder/h2o:0 mod/decoder/b_o:0 mod/attn/dec:0 mod/attn/enc:0 mod/attn/vec:0 mod/embedding_1/embeddings:0 mod/embedding_2/embeddings:0 mod/dense_1/kernel:0 mod/dense_1/bias:0 teacher/embedding_3/embeddings:0 **teacher/embedding_4/embeddings:0 teacher/dense_2/kernel:0 teacher/dense_2/bias:0**

Looks like keras ignores tensorflow name spaces for embeddings and last dense layer, so teacher model is not properly loaded. Hardfixing layers' names seems to help.