### PR TITLE
UnicodeDecodeError in ./week01_embeddings/seminar.ipynb

### DIFF
--- a/week01_embeddings/seminar.ipynb
+++ b/week01_embeddings/seminar.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "data = list(open(\"./quora.txt\"))\n",
+    "data = list(open(\"./quora.txt\", encoding=\"utf-8\"))\n",
     "data[50]"
    ]
   },
@@ -575,7 +575,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix problem while opening in docker container.

Problem occurs while running ./week01_embeddings/seminar.ipynb in docker container. What i found in [documentation](https://docs.python.org/3.5/library/functions.html#open) is that Python 3 build-in function open(filename) by default set encoding parameter equal to the output of locale.getpreferredencoding(False) function. Which is in case of running in docker equal to 'ANSI_X3.4-1968'.

There are two solutions I know. The first one is to use encoding="utf-8" parameter in open() function. Another one is to set proper locale in Dockerfile

An output of locale in bash:
```bash
root@someid:~# locale
LANG=
LANGUAGE=
LC_CTYPE="POSIX"
LC_NUMERIC="POSIX"
LC_TIME="POSIX"
LC_COLLATE="POSIX"
LC_MONETARY="POSIX"
LC_MESSAGES="POSIX"
LC_PAPER="POSIX"
LC_NAME="POSIX"
LC_ADDRESS="POSIX"
LC_TELEPHONE="POSIX"
LC_MEASUREMENT="POSIX"
LC_IDENTIFICATION="POSIX"
LC_ALL=
```