### PR TITLE
homework02 tip fix

### DIFF
--- a/week02_classification/homework_part2.ipynb
+++ b/week02_classification/homework_part2.ipynb
@@ -71,7 +71,7 @@
     "It's not always a good idea to train embeddings from scratch. Here's a few tricks:\n",
     "\n",
     "* Use a pre-trained embeddings from `gensim.downloader.load`. See last lecture.\n",
-    "* Start with pre-trained embeddings, then fine-tune them with gradient descent. You may or may not want to use __`.get_keras_embedding()`__ method for word2vec\n",
+    "* Start with pre-trained embeddings, then fine-tune them with gradient descent. You may or may not download pre-trained embeddings from [here](http://nlp.stanford.edu/data/glove.6B.zip) and follow this [manual](https://keras.io/examples/nlp/pretrained_word_embeddings/) to initialize your Keras embedding layer with downloaded weights.\n",
     "* Use the same embedding matrix in title and desc vectorizer\n",
     "\n",
     "\n",
@@ -115,7 +115,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Совет использовать `. get_keras_embedding()` может быть вредным, поскольку метод возвращает keras cлой, который несовместим с tf.keras слоями. Я изначально делал домашку на tf.keras и это повлекло множество сложноинтерпретируемых ошибок и заставить работать это дело у меня так и не вышло. 

Вместо этого предлагается скачать саму матрицу эмбеддингов и поупражняться в матчинге слов из задания со скачанными, тем более что в мануале есть код, как этот файл парсить в словарь.