### PR TITLE
Поправил тест в compute_loss, где проверяется подсчет loss без паддинга

### DIFF
--- a/week03_lm/homework_pytorch.ipynb
+++ b/week03_lm/homework_pytorch.ipynb
@@ -333,8 +333,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loss_1 = compute_loss(dummy_model, to_matrix(dummy_lines, max_len=50))\n",
-    "loss_2 = compute_loss(dummy_model, to_matrix(dummy_lines, max_len=100))\n",
+    "loss_1 = compute_loss(dummy_model, to_matrix(dummy_lines, max_len=15))\n",
+    "loss_2 = compute_loss(dummy_model, to_matrix(dummy_lines, max_len=16))\n",
     "assert (np.ndim(loss_1) == 0) and (0 < loss_1 < 100), \"loss must be a positive scalar\"\n",
     "assert torch.allclose(loss_1, loss_2), 'do not include  AFTER first EOS into loss. '\\\n",
     "    'Hint: use compute_mask. Beware +/-1 errors. And be careful when averaging!'"

--- a/week03_lm/homework_tf.ipynb
+++ b/week03_lm/homework_tf.ipynb
@@ -326,8 +326,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loss_1 = compute_loss(model, to_matrix(dummy_lines, max_len=50))\n",
-    "loss_2 = compute_loss(model, to_matrix(dummy_lines, max_len=100))\n",
+    "loss_1 = compute_loss(model, to_matrix(dummy_lines, max_len=15))\n",
+    "loss_2 = compute_loss(model, to_matrix(dummy_lines, max_len=16))\n",
     "assert (np.ndim(loss_1) == 0) and (0 < loss_1 < 100), \"loss must be a positive scalar\"\n",
     "assert np.allclose(loss_1, loss_2), 'do not include  AFTER first EOS into loss. '\\\n",
     "    'Hint: use tf.sequence_mask. Beware +/-1 errors. And be careful when averaging!'"


### PR DESCRIPTION
В тртьей домашке про Language Modeling накосячил с подсчетом loss. А именно, вместо того, чтобы считать маску по `inputs[:, 1:]` (то есть по последовательности без BOS), я считал маску по `inputs[:, :-1]` (последовательности без последнего EOS). 

А это неправильно, пример `input = bos A n n a eos eos`. Валидных  5 токенов, а если считать, как я, то получится 6.

Текущий тест это не проверяет, так там стоят очень большие длины для входа `dummy_lines`, у которого максимально возможная длина 15.

![nlp_fix](https://user-images.githubusercontent.com/49318785/95653768-d0c04100-0b03-11eb-83ec-d652d198e84e.png)
