### PR TITLE
Bug - need no_grad() to bleu computation, otherwise huge memory consumption

### DIFF
--- a/week04_seq2seq/practice_and_homework_pytorch.ipynb
+++ b/week04_seq2seq/practice_and_homework_pytorch.ipynb
@@ -485,13 +485,14 @@
     "    Estimates corpora-level BLEU score of model's translations given inp and reference out\n",
     "    Note: if you're serious about reporting your results, use https://pypi.org/project/sacrebleu\n",
     "    \"\"\"\n",
-    "    translations, _ = model.translate_lines(inp_lines, **flags)\n",
-    "    translations = [line.replace(bpe_sep, '') for line in translations] \n",
-    "    return corpus_bleu(\n",
-    "        [[ref.split()] for ref in out_lines],\n",
-    "        [trans.split() for trans in translations],\n",
-    "        smoothing_function=lambda precisions, **kw: [p + 1.0 / p.denominator for p in precisions]\n",
-    "        ) * 100"
+    "    with torch.no_grad():\n",
+    "        translations, _ = model.translate_lines(inp_lines, **flags)\n",
+    "        translations = [line.replace(bpe_sep, '') for line in translations] \n",
+    "        return corpus_bleu(\n",
+    "            [[ref.split()] for ref in out_lines],\n",
+    "            [trans.split() for trans in translations],\n",
+    "            smoothing_function=lambda precisions, **kw: [p + 1.0 / p.denominator for p in precisions]\n",
+    "            ) * 100"
    ]
   },
   {
@@ -960,7 +961,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
HW4 (seq2seq)
Huge memory consumption leads to OOM due to gradients computation in calculation BLEU score. It is provided as ready block of code, so it takes a lot of time to find this.

Let's save nerves of our colleagues!