### PR TITLE
Change requirements in seminar_1

### DIFF
--- a/week01_embeddings/seminar.ipynb
+++ b/week01_embeddings/seminar.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "This whole thing is gonna happen on top of embedding dataset.\n",
     "\n",
-    "__Requirements:__  `pip install --upgrade nltk gensim bokeh` , but only if you're running locally."
+    "__Requirements:__  `pip install --upgrade nltk gensim==3.8 bokeh` , but only if you're running locally."
    ]
   },
   {


### PR DESCRIPTION
I changed the requirements in the week01_embeddings/seminar.ipynb because with the gensim upgrade to 4.0, some methods and attributes have been replaced. For example, `model = Word2Vec(size=100, …)` was replaced `model = Word2Vec(vector_size=100, …)`. More details: https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4