### PR TITLE
pandas.read_csv directly from zip

### DIFF
--- a/week02_classification/seminar.ipynb
+++ b/week02_classification/seminar.ipynb
@@ -42,8 +42,7 @@
    "outputs": [],
    "source": [
     "!wget https://ysda-seminars.s3.eu-central-1.amazonaws.com/Train_rev1.zip\n",
-    "!unzip Train_rev1.zip\n",
-    "data = pd.read_csv(\"./Train_rev1.csv\", index_col=None)\n",
+    "data = pd.read_csv(\"./Train_rev1.zip\", compression='zip', index_col=None)\n",
     "data.shape"
    ]
   },


### PR DESCRIPTION
saves time and disk space
works with single csv per zip (multiple files per archive possible with other compression methods)
docs ref: https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html