### PR TITLE
passing thru device parameters in `iterate_minibatches`

### DIFF
--- a/week02_classification/seminar.ipynb
+++ b/week02_classification/seminar.ipynb
@@ -534,7 +534,7 @@
     "            indices = np.random.permutation(indices)\n",
     "\n",
     "        for start in range(0, len(indices), batch_size):\n",
-    "            batch = make_batch(data.iloc[indices[start : start + batch_size]], **kwargs)\n",
+    "            batch = make_batch(data.iloc[indices[start : start + batch_size]], device=device, **kwargs)\n",
     "            yield batch\n",
     "        \n",
     "        if not cycle: break"


### PR DESCRIPTION
passing thru `device` parameter in call to `make_batch()` from `iterate_minibatches()`