### PR TITLE
added `device` param in `print_metrics()`

### DIFF
--- a/week02_classification/seminar.ipynb
+++ b/week02_classification/seminar.ipynb
@@ -568,11 +568,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def print_metrics(model, data, batch_size=BATCH_SIZE, name=\"\", **kw):\n",
+    "def print_metrics(model, data, batch_size=BATCH_SIZE, name=\"\", device=torch.device('cpu'), **kw):\n",
     "    squared_error = abs_error = num_samples = 0.0\n",
     "    model.eval()\n",
     "    with torch.no_grad():\n",
-    "        for batch in iterate_minibatches(data, batch_size=batch_size, shuffle=False, **kw):\n",
+    "        for batch in iterate_minibatches(data, batch_size=batch_size, shuffle=False, device=device, **kw):\n",
     "            batch_pred = model(batch)\n",
     "            squared_error += torch.sum(torch.square(batch_pred - batch[TARGET_COLUMN]))\n",
     "            abs_error += torch.sum(torch.abs(batch_pred - batch[TARGET_COLUMN]))\n",


### PR DESCRIPTION
added `device` param in `print_metrics()` for use in call to `iterate_minibatches()` - helps when running with CUDA