### PR TITLE
Update `gensim.model.vocab` call in seminar 1

### DIFF
--- a/week01_embeddings/seminar.ipynb
+++ b/week01_embeddings/seminar.ipynb
@@ -194,9 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "words = sorted(model.vocab.keys(), \n",
-    "               key=lambda word: model.vocab[word].count,\n",
-    "               reverse=True)[:1000]\n",
+    "words = model.index_to_key[:1000] \n",
     "\n",
     "print(words[::100])"
    ]

--- a/week03_lm/seminar.ipynb
+++ b/week03_lm/seminar.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "# assemble lines: concatenate title and description\n",
-    "lines = data.apply(lambda row: row['title'] + ' ; ' + row['summary'], axis=1).tolist()\n",
+    "lines = data.apply(lambda row: row['title'] + ' ; ' + row['summary'].replace('\n', ' '), axis=1).tolist()\n",
     "\n",
     "sorted(lines, key=len)[:3]"
    ]


### PR DESCRIPTION
replaced call to `model.vocab` with call to `model.index_to_key` to be compatible with `gensim v.4`. no extra sorting is needed - index_to_key is effectively coming in the order of keys.

This code was not run at the seminar in sep-2022.