### PR TITLE
replaced hard breaks in corpus for Seminar-3

### DIFF
--- a/week03_lm/seminar.ipynb
+++ b/week03_lm/seminar.ipynb
@@ -47,7 +47,7 @@
    "outputs": [],
    "source": [
     "# assemble lines: concatenate title and description\n",
-    "lines = data.apply(lambda row: row['title'] + ' ; ' + row['summary'], axis=1).tolist()\n",
+    "lines = data.apply(lambda row: row['title'] + ' ; ' + row['summary'].replace('\n', ' '), axis=1).tolist()\n",
     "\n",
     "sorted(lines, key=len)[:3]"
    ]


### PR DESCRIPTION
Исходный корпус текстов записан с переносами строки, что создаёт нежелательные артефакты типа слов `deep\nlearning`, особенно заметные при применении сглаживания. Помогает в самом начале нотбука, после загрузки `lines` заменить `\n`.