### PR TITLE
Sem-1 updated gensim.model.vocab call to v.4 style

### DIFF
--- a/week01_embeddings/seminar.ipynb
+++ b/week01_embeddings/seminar.ipynb
@@ -194,9 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "words = sorted(model.vocab.keys(), \n",
-    "               key=lambda word: model.vocab[word].count,\n",
-    "               reverse=True)[:1000]\n",
+    "words = model.index_to_key[:1000] \n",
     "\n",
     "print(words[::100])"
    ]


### PR DESCRIPTION
replaced call to `model.vocab` with call to `model.index_to_key` to be compatible with `gensim v.4`. no extra sorting is needed - index_to_key is effectively coming in the order of keys.