### PR TITLE
updated decodestring to decodebytes in seminar 5

### DIFF
--- a/week05_transfer/seminar.ipynb
+++ b/week05_transfer/seminar.ipynb
@@ -68,7 +68,7 @@
     "<...>\n",
     "outputs = <YOUR CODE: dict (house name) : True if positive, False if negative>\n",
     "\n",
-    "assert sum(outputs.values()) == 3 and outputs[base64.decodestring(b'YmFyYXRoZW9u\\n').decode()] == False\n",
+    "assert sum(outputs.values()) == 3 and outputs[base64.decodebytes(b'YmFyYXRoZW9u\\n').decode()] == False\n",
     "print(\"Well done!\")"
    ]
   },


### PR DESCRIPTION
to address  DeprecationWarning: decodestring() is a deprecated alias since Python 3.1, use decodebytes()