### PR TITLE
Fixed legacy model output interpretation

### DIFF
--- a/week05_transfer/seminar.ipynb
+++ b/week05_transfer/seminar.ipynb
@@ -226,9 +226,9 @@
    "source": [
     "# You can now apply the model to get embeddings\n",
     "with torch.no_grad():\n",
-    "    token_embeddings, sentence_embedding = model(**tokens_info)\n",
+    "    out = model(**tokens_info)\n",
     "\n",
-    "print(sentence_embedding)"
+    "print(out['pooler_output'])"
    ]
   },
   {


### PR DESCRIPTION
 Since one of the 3.X releases of the transformers library, the models do not return tuples anymore but specific output objects.