### PR TITLE
replaced link to conll2003 dataset card in HW-6

### DIFF
--- a/week06_da/homework.ipynb
+++ b/week06_da/homework.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "### Source domain testset\n",
     "\n",
-    "Our train set consists from texts from different news sources. Therefore as source-domain testset we will use data from [CoNLL-2003 Shared Task](https://github.com/Franck-Dernoncourt/NeuroNER/blob/master/data/conll2003/en). More information about the task can be found [here](https://www.clips.uantwerpen.be/conll2003/ner/).\n",
+    "Our train set consists from texts from different news sources. Therefore as source-domain testset we will use data from [CoNLL-2003 Shared Task](https://huggingface.co/datasets/conll2003). More information about the task can be found [here](https://www.clips.uantwerpen.be/conll2003/ner/).\n",
     "\n",
     "### Target domain (in-domain) data\n",
     "\n",


### PR DESCRIPTION
the old link is still present at Frank's repo front page, but not active )
New link is to the HF model card.
matching issue open at Frank's repo: https://github.com/Franck-Dernoncourt/NeuroNER/issues/184