### PR TITLE
Limit input length of GPT2

### DIFF
--- a/week05_transfer/seminar.ipynb
+++ b/week05_transfer/seminar.ipynb
@@ -277,7 +277,7 @@
     "\n",
     "text = \"The Fermi paradox \"\n",
     "tokens = tokenizer.encode(text)\n",
-    "num_steps = 1024\n",
+    "num_steps = 1024 - len(tokens) + 1\n",
     "line_length, max_length = 0, 70\n",
     "\n",
     "print(end=tokenizer.decode(tokens))\n",


### PR DESCRIPTION
With non-empty prefix `text = "The Fermi paradox "` and `num_steps = 1024`, the model input could exceed 1024 tokens, which resulted in CUDA failures *(GPT2 uses absolute position embeddings)*:
```
/opt/pytorch/pytorch/aten/src/ATen/native/cuda/Indexing.cu:703: indexSelectLargeIndex: block: [99,0,0], thread: [72,0,0] Assertion `srcIndex < srcSelectDimSize` failed.
```
