### PR TITLE
updated dummy loss target shape in adapter test

### DIFF
--- a/week08_llm/practice.ipynb
+++ b/week08_llm/practice.ipynb
@@ -519,7 +519,7 @@
         "test_adapter.adapter_B.data[...] = torch.linspace(0.5, -0.1, 128 * 8).view(8, 128)\n",
         "test_linear.bias.data[...] = torch.linspace(1., -1., 128)\n",
         "\n",
-        "dummy_loss = F.mse_loss(test_adapter(torch.ones(1, 128) / 128), torch.linspace(-1, 1, 128))\n",
+        "dummy_loss = F.mse_loss(test_adapter(torch.ones(1, 128) / 128), torch.linspace(-1, 1, 128).unsqueeze(0))\n",
         "assert torch.allclose(dummy_loss, torch.tensor(1.3711389), rtol=0, atol=1e-4)\n",
         "dummy_loss.backward()\n",
         "assert all(w.grad is not None for w in [test_adapter.adapter_A, test_adapter.adapter_B]), \"some adapter weights have no grad\"\n",


### PR DESCRIPTION
avoids warning `UserWarning: Using a target size (torch.Size([128])) that is different to the input size (torch.Size([1, 128])). This will likely lead to incorrect results due to broadcasting. Please ensure they have the same size.
  dummy_loss = F.mse_loss(test_adapter(torch.ones(1, 128) / 128), torch.linspace(-1, 1, 128))`