### PR TITLE
fixed fd leakage

### DIFF
--- a/week01_embeddings/seminar.ipynb
+++ b/week01_embeddings/seminar.ipynb
@@ -36,7 +36,9 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "data = list(open(\"./quora.txt\", encoding=\"utf-8\"))\n",
+    "with open(\"./quora.txt\", encoding=\"utf-8\") as file:\n",
+    "    data = list(file)\n",
+    "\n",
     "data[50]"
    ]
   },


### PR DESCRIPTION
Code like `list(open("./quora.txt"))` leaks file descriptors, as it does not call `.close()` method on file. It's better to use it with `with`.