### PR TITLE
fix: Added additional assert on week01 seminar to meet all get_phrase_embedding requirements

### DIFF
--- a/week01_embeddings/seminar.ipynb
+++ b/week01_embeddings/seminar.ipynb
@@ -409,7 +409,8 @@
     "assert np.allclose(vector[::10],\n",
     "                   np.array([ 0.31807372, -0.02558171,  0.0933293 , -0.1002182 , -1.0278689 ,\n",
     "                             -0.16621883,  0.05083408,  0.17989802,  1.3701859 ,  0.08655966],\n",
-    "                              dtype=np.float32))"
+    "                              dtype=np.float32))\n",
+    "assert np.array_equal(get_phrase_embedding(\"thisisgibberish\"), np.zeros([model.vector_size], dtype='float32')), \"corner case for all missing words should be handled as described in the function comments\""
    ]
   },
   {


### PR DESCRIPTION
In week01 seminar code in the `get_phrase_embedding` function there's a requirement to return all zeros if no words are recognized in the phrase.

However, it's not checked in following asserts and may backfire only in the `find_nearest` function during the dot product operation with a non-intuitive "dimensions don't match" error.

I'd suggest to add an additional assert to check for the corner case requirement and save students' time.