### PR TITLE
fix: Week01 homework typos

### DIFF
--- a/week01_embeddings/homework.ipynb
+++ b/week01_embeddings/homework.ipynb
@@ -284,7 +284,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As quality measure we will use precision top-1, top-5 and top-10 (for each transformed Ukrainian embedding we count how many right target pairs are found in top N nearest neighbours in Russian embedding space)."
+    "As a quality measure we will use precision top-1, top-5 and top-10 (for each transformed Ukrainian embedding we count how many right target pairs are found in top N nearest neighbours in Russian embedding space)."
    ]
   },
   {


### PR DESCRIPTION
Fixed some minor typos

"As a measure" instead of "as measure" because:

![Screenshot 2024-01-05 at 9 51 13 PM](https://github.com/yandexdataschool/nlp_course/assets/18697399/89bae63f-8908-464b-85a8-a6438d19b6ef)

![Screenshot 2024-01-05 at 9 51 18 PM](https://github.com/yandexdataschool/nlp_course/assets/18697399/bc29527d-5264-4004-91a0-8de622b4d442)

![Screenshot 2024-01-05 at 9 51 23 PM](https://github.com/yandexdataschool/nlp_course/assets/18697399/67a25305-d0be-46e1-8855-be7e77115f6c)
