### PR TITLE
fix: Fixed 404 on main page readme schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
   - Homework: fine-tuning a pre-trained BERT model
 
 
-- [__week06__](./week6_llm) __LLMs and Prompting__
+- [__week06__](./week06_llm) __LLMs and Prompting__
   - Lecture: Scaling laws. Emergent abilities. Prompting (aka "in-context learning"): techiques that work; questioning whether model "understands" prompts. Hypotheses for why and how in-context learning works. Analysis and Interpretability.
   - Homework: manual prompt engneering and chain-of-thought reasoning
 


### PR DESCRIPTION
Week06 readme link currently leads to 404

![image](https://github.com/yandexdataschool/nlp_course/assets/18697399/8e5f3d7d-8bf7-46d7-97a3-a27e398b8027)
