### PR TITLE
Additional assert for count_ngrams

### DIFF
--- a/week03_lm/seminar.ipynb
+++ b/week03_lm/seminar.ipynb
@@ -191,9 +191,9 @@
     "assert len(dummy_counts[('_UNK_', '_UNK_')]) == 78\n",
     "assert dummy_counts['_UNK_', 'a']['note'] == 3\n",
     "assert dummy_counts['p', '=']['np'] == 2\n",
-    "assert dummy_counts['author', '.']['_EOS_'] == 1",
+    "assert dummy_counts['author', '.']['_EOS_'] == 1\n",
     "\n",
-    "single_counts = count_ngrams(dummy_lines, n=1)",
+    "single_counts = count_ngrams(dummy_lines, n=1)\n",
     "assert single_counts[()][EOS] == len(dummy_lines)"
    ]
   },

--- a/week03_lm/seminar.ipynb
+++ b/week03_lm/seminar.ipynb
@@ -191,7 +191,10 @@
     "assert len(dummy_counts[('_UNK_', '_UNK_')]) == 78\n",
     "assert dummy_counts['_UNK_', 'a']['note'] == 3\n",
     "assert dummy_counts['p', '=']['np'] == 2\n",
-    "assert dummy_counts['author', '.']['_EOS_'] == 1"
+    "assert dummy_counts['author', '.']['_EOS_'] == 1",
+    "\n",
+    "single_counts = count_ngrams(dummy_lines, n=1)",
+    "assert single_counts[()][EOS] == len(dummy_lines)"
    ]
   },
   {


### PR DESCRIPTION
I have spent quite some time trying to find an error in my function to compute perplexity for the case n=1. I got 321 instead of desired 318.

It turns out that the mistake was in count_ngrams, and for the case n=1 I have counted EOS twice. In order to find a similar mistake earlier and spend a little bit less time then I did, I propose to add one more assert for this corner-case.