### PR TITLE
Update seminar.ipynb

### DIFF
--- a/week01_embeddings/seminar.ipynb
+++ b/week01_embeddings/seminar.ipynb
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "# download the data:\n",
-    "!wget https://www.dropbox.com/s/obaitrix9jyu84r/quora.txt?dl=1 -O ./quora.txt\n",
+    "!wget \"https://www.dropbox.com/s/obaitrix9jyu84r/quora.txt?dl=1\" -O ./quora.txt\n",
     "# alternative download link: https://yadi.sk/i/BPQrUu1NaTduEw"
    ]
   },


### PR DESCRIPTION
This cell doesn't work with zsh and without quotes. 

zsh:1: no matches found: https://www.dropbox.com/s/obaitrix9jyu84r/quora.txt?dl=1

(MacOS)